### PR TITLE
Fix issue opening RaceDB dialog

### DIFF
--- a/RaceDB.py
+++ b/RaceDB.py
@@ -249,7 +249,8 @@ class RaceDB( wx.Dialog ):
 					url=self.fixUrl(),
 					date=datetime.date( d.GetYear(), d.GetMonth()+1, d.GetDay() ),
 				)
-			except Exception as e:
+			except Exception as _e:
+				e = _e
 				events = {'events':[]}
 
 		if not e and not (events and events.get('events',None)):


### PR DESCRIPTION
Python 3 removes `e` from scope when leaving the exception handling logic. Catch the exception to a different variable, then assign to `e`.

Demonstrated in this test program:

```python
e = None

try:
    raise ValueError("Whomp whomp")
except Exception as e:
    pass

print(e)
```

[The PyDoc explains this](https://docs.python.org/3/reference/compound_stmts.html#the-try-statement):

> When an exception has been assigned using as target, it is cleared at the end of the except clause. This is as if
> 
> ```python
> except E as N:
>     foo
> ```
> was translated to
> ```python
> except E as N:
>     try:
>         foo
>     finally:
>         del N
> ```
>
> This means the exception must be assigned to a different name to be able to refer to it after the except clause. Exceptions are cleared because with the traceback attached to them, they form a reference cycle with the stack frame, keeping all locals in that frame alive until the next garbage collection occurs.

I also learned this today, and have a bunch of my own code to clean up now!