### PR TITLE
fix issue #31... Just add some error handling!

### DIFF
--- a/CrossMgrImpinj/Impinj.py
+++ b/CrossMgrImpinj/Impinj.py
@@ -504,6 +504,19 @@ class Impinj( object ):
 						self.messageQ.put( ('Impinj', 'Listening for Impinj reader data...') )
 						tUpdateLast = t
 					continue
+				except Exception as e:
+					t = getTimeNow()
+					
+					if (t - tKeepaliveLast).total_seconds() > KeepaliveSeconds * 2:
+						self.messageQ.put( ('Impinj', 'Reader Connection Lost (Check your network adapter).') )
+						self.readerSocket.close()
+						self.messageQ.put( ('Impinj', 'Attempting Reconnect...') )
+						break
+					
+					if (t - tUpdateLast).total_seconds() >= ReaderUpdateMessageSeconds:
+						self.messageQ.put( ('Impinj', 'Listening for Impinj reader data...') )
+						tUpdateLast = t
+					continue
 				
 				if isinstance(response, KEEPALIVE_Message):
 					# Respond to the KEEP_ALIVE message with KEEP_ALIVE_ACK.


### PR DESCRIPTION
I figured this problem out! All it took, was to add some error handling to catch the `ConnectionResetError: [WinError 10054] An existing connection was forcibly closed by the remote host` error, and run the already existing `except socket.timeout` code again with a note pointing to the network adapter.

One could also catch the same error with just `ConnectionResetError`, but I figured the `Exception as e` was already being used in many places, so decided to just reuse it here.

This totally solves the problem as I would've expected.