### PR TITLE
add ValidateTmeFormat() & proposal for Linux/Mac

### DIFF
--- a/ChipImport.py
+++ b/ChipImport.py
@@ -16,11 +16,23 @@ from HighPrecisionTimeEdit import HighPrecisionTimeEdit
 def DoChipImport(	fname, parseTagTime, startTime = None,
 					clearExistingData = True, timeAdjustment = None ):
 	
+	errors = []
+
 	race = Model.race
 	if race and race.isRunning():
 		Utils.MessageOK( Utils.getMainWin(), u'\n\n'.join( [_('Cannot Import into a Running Race.'), _('Wait until you have a complete data set, then import the full data into a New race.')] ),
 						title = _('Cannot Import into Running Race'), iconMask = wx.ICON_ERROR )
 		return
+
+	try:
+		if HighPrecisionTimeEdit.ValidateTimeFormat(startTime):
+			return True
+		# datetime.datetime.strptime(timeAdjustment, '%H:%M:%S')
+	except Exception:
+		Utils.MessageOK( Utils.getMainWin(), u'\n\n'.join( [_('Invalid time formatting'), _('You must ensure that the time contains at least "HH:MM:SS".'),
+		_('Fractions of a second are optional. Default time formatting is 00:00:00.000 in 24-hour format')] ),
+					title = _('Invalid time formatting'), iconMask = wx.ICON_ERROR )
+		return errors
 	
 	# If startTime is None, the first time will be taken as the start time.
 	# All first time's for each rider will then be ignored.
@@ -28,7 +40,6 @@ def DoChipImport(	fname, parseTagTime, startTime = None,
 	if timeAdjustment is None:
 		timeAdjustment = datetime.timedelta(seconds=0.0)
 	
-	errors = []
 	raceStart = None
 	
 	with io.open(fname, encoding='utf-8') as f, Model.LockRace() as race:


### PR DESCRIPTION
Proposed to fix https://github.com/esitarski/CrossMgr/issues/26

Added new ValidateTimeFormat() to HighPrecisionTimeEdit and also onPaste() . Also added final validation check to ChipImport.py.. The same could also be added in other places, if approved. onPaste() shows a yellow tooltip below the boxes if the time formatting is incorrect.
![hpte](https://user-images.githubusercontent.com/16664350/73355722-68953c00-42a1-11ea-82ae-dbe8e19ffb12.png)

onDoubleClick() changes the TextCtrl function so that only a double-click is required to select the whole box, and not a triple-click