### PR TITLE
Ignore RFID for unstarted time trial riders

### DIFF
--- a/MainWin.py
+++ b/MainWin.py
@@ -4130,7 +4130,14 @@ Computers fail, screw-ups happen.  Always use a manual backup.
 				
 			# Only process times after the start of the race.
 			if race.isRunning() and race.startTime <= dt:
-				self.numTimes.append( (num, (dt - race.startTime).total_seconds()) )
+				#Always process times for mass start races and when timeTrialNoRFIDStart unset.
+				if not race.isTimeTrial or not race.timeTrialNoRFIDStart:
+					self.numTimes.append( (num, (dt - race.startTime).total_seconds()) )
+				else:
+					#Only process the time if the rider has already started
+					rider = race.getRider( num )
+					if rider.firstTime is not None:
+						self.numTimes.append( (num, (dt - race.startTime).total_seconds()) )
 		
 		# Ensure that we don't update too often if riders arrive in a bunch.
 		if not self.callLaterProcessRfidRefresh:

--- a/Model.py
+++ b/Model.py
@@ -1112,6 +1112,7 @@ class Race:
 	estimateLapsDownFinishTime = False
 	
 	enableJChipIntegration = False
+	timeTrialNoRFIDStart = False
 	resetStartClockOnFirstTag = False
 	firstRecordedTime = None
 	skipFirstTagRead = False

--- a/Properties.py
+++ b/Properties.py
@@ -344,6 +344,8 @@ class RfidProperties( wx.Panel ):
 		)
 		
 		self.chipTimingOptions.SetSelection( self.iResetStartClockOnFirstTag )
+
+		self.ignoreTTStart = wx.CheckBox( self, label = _('Ignore RFID reads for unstarted time trial riders.') + '  \n' + ('Riders must be started manually, or by using a spreadsheet.') )
 		
 		hs = wx.BoxSizer( wx.HORIZONTAL )
 		self.chipReaderChoices = ChipReader.ChipReader.Choices
@@ -359,6 +361,7 @@ class RfidProperties( wx.Panel ):
 		
 		ms.Add( self.jchip, flag=wx.ALL, border=16 )
 		ms.Add( self.chipTimingOptions, flag=wx.ALL, border=4 )
+		ms.Add( self.ignoreTTStart, flag=wx.ALL, border=16 )
 		ms.Add( hs, flag=wx.ALL, border=4 )
 		ms.AddSpacer( 16 )
 		ms.Add( self.setupButton, flag=wx.ALL, border=4 )
@@ -377,6 +380,7 @@ class RfidProperties( wx.Panel ):
 		if not race:
 			return
 		self.jchip.SetValue( getattr(race, 'enableJChipIntegration', False) )
+		self.ignoreTTStart.SetValue( getattr(race, 'timeTrialNoRFIDStart', False) )
 		resetStartClockOnFirstTag = getattr(race, 'resetStartClockOnFirstTag', True)
 		skipFirstTagRead = getattr(race, 'skipFirstTagRead', False)
 		if resetStartClockOnFirstTag:
@@ -393,6 +397,7 @@ class RfidProperties( wx.Panel ):
 		if not race:
 			return
 		race.enableJChipIntegration = self.jchip.IsChecked()
+		race.timeTrialNoRFIDStart = self.manualTTStart.IsChecked()
 		iSelection = self.chipTimingOptions.GetSelection()
 		race.resetStartClockOnFirstTag	= bool(iSelection == self.iResetStartClockOnFirstTag)
 		race.skipFirstTagRead			= bool(iSelection == self.iSkipFirstTagRead)

--- a/Properties.py
+++ b/Properties.py
@@ -397,7 +397,7 @@ class RfidProperties( wx.Panel ):
 		if not race:
 			return
 		race.enableJChipIntegration = self.jchip.IsChecked()
-		race.timeTrialNoRFIDStart = self.manualTTStart.IsChecked()
+		race.timeTrialNoRFIDStart = self.ignoreTTStart.IsChecked()
 		iSelection = self.chipTimingOptions.GetSelection()
 		race.resetStartClockOnFirstTag	= bool(iSelection == self.iResetStartClockOnFirstTag)
 		race.skipFirstTagRead			= bool(iSelection == self.iSkipFirstTagRead)

--- a/helptxt/Properties.md
+++ b/helptxt/Properties.md
@@ -177,6 +177,13 @@ The idea behind this feature is that the riders are staged in a start area behin
 
 When using this feature, be sure to set the "First Lap Distance" in [Categories][] to compensate for the run-up distance.  This will ensure that the riders speeds are computed correctly.
 
+
+### Ignore RFID reads for unstarted time trial riders.  Riders must be started manually, or by using a spreadsheet.
+This option only affects time trials.  It ignores all tag reads for a rider until after they have started.
+
+This allows you to use the RFID system to record riders' lap/finish times without having to keep riders who are waiting to start out of range of the RFID reader.  Useful when there isn't room for a start area away from the finish line.
+
+
 ### Reader Type
 Either JChip/Impinj/Alien or RaceResult.  See [ChipReader][] for more details.
 

--- a/helptxt/TimeTrial.md
+++ b/helptxt/TimeTrial.md
@@ -65,9 +65,10 @@ On race day:
 CrossMgr can be used for "informal" time trials - without a start list.
 
 With no start times, the first recorded time will start the rider's clock.
-Simply enter the bib number to start the rider.
+Simply enter the bib number to start the rider.  If you do not want RFID reads to start the rider, check the "Ignore RFID reads for unstarted time trial riders." checkbox in the RFID properties.
 
 Subsequent entries for that rider will count as usual (either the finish, or towards laps if the TT is multi-lap).
+
 
 ## Both Automatic Starts and Manual Starts
 


### PR DESCRIPTION
Adds an option to ignore RFID reads for un-started riders in time trial mode.  Once riders have been started, their tag reads are processed normally.

This means you can run an informal time trial (manually starting riders in the order they become ready), using the RFID system for the finish, without having to cat-herd everyone out of range of the RFID system before starting the clock.  This is useful at sites with limited space, or where riders are likely to walk past the finish line to access facilities such as toilets.

The setting has no effect on mass-start races.