### PR TITLE
Make race name editable in SeriesMgr

### DIFF
--- a/SeriesMgr/Races.py
+++ b/SeriesMgr/Races.py
@@ -61,7 +61,7 @@ class Races(wx.Panel):
 		self.grid.SetColAttr( self.TeamPointsCol, attr )
 		
 		attr = gridlib.GridCellAttr()
-		attr.SetReadOnly( True )
+		#attr.SetReadOnly( True )
 		self.grid.SetColAttr( self.RaceCol, attr )
 		
 		attr = gridlib.GridCellAttr()
@@ -212,11 +212,12 @@ class Races(wx.Panel):
 			pname = self.grid.GetCellValue( row, self.PointsCol )
 			pteamname = self.grid.GetCellValue( row, self.TeamPointsCol ) or None
 			grade = self.grid.GetCellValue(row, self.GradeCol).strip().upper()[:1]
+			raceName = self.grid.GetCellValue( row, self.RaceCol ).strip()
 			if not (grade and ord('A') <= ord(grade) <= ord('Z')):
 				grade = 'A'
 			if not fileName or not pname:
 				continue
-			raceList.append( (fileName, pname, pteamname, grade) )
+			raceList.append( (fileName, pname, pteamname, grade, raceName) )
 		
 		model = SeriesModel.model
 		model.setRaces( raceList )

--- a/SeriesMgr/Results.py
+++ b/SeriesMgr/Results.py
@@ -447,7 +447,7 @@ function sortTableId( iTable, iCol ) {
 					numPlacesTieBreaker=model.numPlacesTieBreaker )
 				results = [rr for rr in results if toFloat(rr[3]) > 0.0]
 				
-				headerNames = HeaderNames + ['{}'.format(r[1]) for r in races]
+				headerNames = HeaderNames + ['{}'.format(r[3].raceName) for r in races]
 				
 				with tag(html, 'div', {'id':'catContent{}'.format(iTable)} ):
 					write( '<p/>')
@@ -477,9 +477,9 @@ function sortTableId( iTable, iCol ) {
 											pass
 										if r[2]:
 											with tag(html,'a',dict(href='{}?raceCat={}'.format(r[2], quote(categoryName.encode('utf8')))) ):
-												write( '{}'.format(escape(r[1]).replace('\n', '<br/>\n')) )
+												write( '{}'.format(escape(r[3].raceName).replace('\n', '<br/>\n')) )
 										else:
-											write( '{}'.format(escape(r[1]).replace('\n', '<br/>\n')) )
+											write( '{}'.format(escape(r[3].raceName).replace('\n', '<br/>\n')) )
 										if r[0]:
 											write( '<br/>' )
 											with tag(html, 'span', {'class': 'smallFont'}):
@@ -898,7 +898,7 @@ class Results(wx.Panel):
 		
 		results = [rr for rr in results if toFloat(rr[3]) > 0.0]
 		
-		headerNames = HeaderNames + ['{}\n{}'.format(r[1],r[0].strftime('%Y-%m-%d') if r[0] else '') for r in races]
+		headerNames = HeaderNames + ['{}\n{}'.format(r[3].raceName,r[0].strftime('%Y-%m-%d') if r[0] else '') for r in races]
 		
 		Utils.AdjustGridSize( self.grid, len(results), len(headerNames) )
 		self.setColNames( headerNames )
@@ -1007,7 +1007,7 @@ class Results(wx.Panel):
 			)
 			results = [rr for rr in results if toFloat(rr[3]) > 0.0]
 			
-			headerNames = HeaderNames + [r[1] for r in races]
+			headerNames = HeaderNames + [r[3].raceName for r in races]
 			
 			ws = wb.add_sheet( re.sub('[:\\/?*\[\]]', ' ', categoryName) )
 			wsFit = FitSheetWrapper( ws )

--- a/SeriesMgr/SeriesModel.py
+++ b/SeriesMgr/SeriesModel.py
@@ -156,14 +156,19 @@ class Race:
 	pureTeam = False	# True if the results are by pure teams, that is, no individual results.
 	teamPointStructure = None	# If specified, team points will be recomputed from the top individual results.
 	
-	def __init__( self, fileName, pointStructure, teamPointStructure=None, grade=None ):
+	def __init__( self, fileName, pointStructure, teamPointStructure=None, grade=None, raceName=None ):
 		self.fileName = fileName
 		self.pointStructure = pointStructure
 		self.teamPointStructure = teamPointStructure
 		self.grade = grade or 'A'
+		if raceName is None:
+			self.raceName = RaceNameFromPath( self.fileName )
+		else:
+			self.raceName = raceName
 		
 	def getRaceName( self ):
-		return RaceNameFromPath( self.fileName )
+		#return RaceNameFromPath( self.fileName )
+		return self.raceName
 		
 	def postReadFix( self ):
 		if getattr( self, 'fname', None ):
@@ -174,7 +179,7 @@ class Race:
 		return self.fileName
 		
 	def __repr__( self ):
-		return ', '.join( '{}={}'.format(a, repr(getattr(self, a))) for a in ['fileName', 'pointStructure'] )
+		return ', '.join( '{}={}'.format(a, repr(getattr(self, a))) for a in ['fileName', 'pointStructure', 'raceName'] )
 
 class Category:
 	name = ''
@@ -299,7 +304,7 @@ class SeriesModel:
 		self.setChanged()
 	
 	def setRaces( self, raceList ):
-		if [(r.fileName, r.pointStructure.name, r.teamPointStructure.name if r.teamPointStructure else None, r.grade) for r in self.races] == raceList:
+		if [(r.fileName, r.pointStructure.name, r.teamPointStructure.name if r.teamPointStructure else None, r.grade, r.raceName) for r in self.races] == raceList:
 			return
 		
 		self.setChanged()
@@ -307,7 +312,7 @@ class SeriesModel:
 		racesSeen = set()
 		newRaces = []
 		ps = { p.name:p for p in self.pointStructures }
-		for fileName, pname, pteamname, grade in raceList:
+		for fileName, pname, pteamname, grade, racename in raceList:
 			fileName = fileName.strip()
 			if not fileName or fileName in racesSeen:
 				continue
@@ -319,7 +324,7 @@ class SeriesModel:
 			except KeyError:
 				continue
 			pt = ps.get( pteamname, None )
-			newRaces.append( Race(fileName, p, pt, grade) )
+			newRaces.append( Race(fileName, p, pt, grade, racename) )
 			
 		self.races = newRaces
 		for i, r in enumerate(self.races):

--- a/SeriesMgr/TeamResults.py
+++ b/SeriesMgr/TeamResults.py
@@ -448,7 +448,7 @@ function sortTableId( iTable, iCol ) {
 					numPlacesTieBreaker=model.numPlacesTieBreaker )
 				results = [rr for rr in results if toFloat(rr[1]) > 0.0]
 				
-				headerNames = HeaderNames + ['{}'.format(r[1]) for r in races]
+				headerNames = HeaderNames + ['{}'.format(r[3].raceName) for r in races]
 				
 				with tag(html, 'div', {'id':'catContent{}'.format(iTable)} ):
 					write( '<p/>')
@@ -477,9 +477,9 @@ function sortTableId( iTable, iCol ) {
 											pass
 										if r[2]:
 											with tag(html,'a',dict(href='{}?raceCat={}'.format(r[2], quote(categoryName.encode('utf8')))) ):
-												write( '{}'.format(escape(r[1]).replace('\n', '<br/>\n')) )
+												write( '{}'.format(escape(r[3].raceName).replace('\n', '<br/>\n')) )
 										else:
-											write( '{}'.format(escape(r[1]).replace('\n', '<br/>\n')) )
+											write( '{}'.format(escape(r[3].raceName).replace('\n', '<br/>\n')) )
 										if r[0]:
 											write( '<br/>' )
 											with tag(html, 'span', {'class': 'smallFont'}):
@@ -798,7 +798,7 @@ class TeamResults(wx.Panel):
 		)
 		results = [rr for rr in results if toFloat(rr[1]) > 0.0]
 		
-		headerNames = HeaderNames + ['{}\n{}'.format(r[1],r[0].strftime('%Y-%m-%d') if r[0] else '') for r in races]
+		headerNames = HeaderNames + ['{}\n{}'.format(r[3].raceName,r[0].strftime('%Y-%m-%d') if r[0] else '') for r in races]
 		
 		Utils.AdjustGridSize( self.grid, len(results), len(headerNames) )
 		self.setColNames( headerNames )
@@ -901,7 +901,7 @@ class TeamResults(wx.Panel):
 			)
 			results = [rr for rr in results if toFloat(rr[1]) > 0.0]
 			
-			headerNames = HeaderNames + [r[1] for r in races]
+			headerNames = HeaderNames + [r[3].raceName for r in races]
 			
 			ws = wb.add_sheet( re.sub('[:\\/?*\[\]]', ' ', categoryName) )
 			wsFit = FitSheetWrapper( ws )

--- a/SeriesMgr/helptxt/QuickStart.txt
+++ b/SeriesMgr/helptxt/QuickStart.txt
@@ -55,6 +55,7 @@ In each row, add the race, either a CrossMgr race file (.cmn) or an Excel sheet 
 
 You can change the order of races by dragging the row in the grey column to the left of the race name.
 
+* The __Race__ column can be edited to change how the race name is displayed in the results.
 * The __Grade__ column is used to break ties (more on that later too).
 * The __Points__ column is the points structure to be used to score that race.  This only applies if you are scoring by Points (more on that later).
 * The __Team Points__ column is the points structure used to score teams for that race.


### PR DESCRIPTION
(Hopefully I've made this pull request against the 'dev' branch correctly.)

A small feature to allow the user to edit the race names as they're displayed/output by SeriesMgr.  This means you can make the naming of races consistent across a series by making changes on the Races screen, rather than having to rename the race files.  This is particularly useful if you're a habitual user of dashes or underscores in filenames, but want spaces in the final output...