### PR TITLE
More robust 'Name' field parsing in SeriesMgr Excel input

### DIFF
--- a/SeriesMgr/GetModelInfo.py
+++ b/SeriesMgr/GetModelInfo.py
@@ -227,7 +227,12 @@ def ExtractRaceResultsExcel( raceInSeries ):
 					try:
 						info['lastName'], info['firstName'] = name.split(',',1)
 					except:
-						pass
+						# Failing that, split on the last space character.
+						try:
+							info['firstName'], info['lastName'] = name.rsplit(' ',1)
+						except:
+							# If there are no spaces to split on, treat the entire name as lastName.  This is fine.
+							info['lastName'] = name
 				
 				if not info['firstName'] and not info['lastName']:
 					continue


### PR DESCRIPTION
If there is only a 'Name' field, and the contents aren't comma-separated, split on the last space in the name if there is one, or failing that, treat the entire thing as LastName.
A minor convenience for working with Excel files that have come from somewhere other than CrossMgr.
This also allows SeriesMgr to reliably read its own Excel output, where the names aren't always comma-separated.