### PR TITLE
Fix early removal of stale intervals

### DIFF
--- a/CrossMgrVideo/CamServer.py
+++ b/CrossMgrVideo/CamServer.py
@@ -278,7 +278,7 @@ def CamServer( qIn, qOut, camInfo=None ):
 					# Remove stale intervals from list.
 					if intervals:
 						tsCutoff = now() - timedelta( seconds=6 )
-						intervals = [ti for ti in intervals if ti.end < tsCutoff]
+						intervals = [ti for ti in intervals if ti.end > tsCutoff]
 				
 def getCamServer( camInfo=None ):
 	qIn = Queue()


### PR DESCRIPTION
Fix bug that causes early removal of stale intervals.  As this is only called every 3 seconds, it wasn't obvious there was a problem if only capturing a couple of seconds of video after the trigger.