### PR TITLE
Fix bug where trigger list appears in reverse order

### DIFF
--- a/CrossMgrVideo/MainWin.py
+++ b/CrossMgrVideo/MainWin.py
@@ -1260,7 +1260,8 @@ class MainWin( wx.Frame ):
 			tsPrev = triggers[i-1].ts if i != 0 else (trig.ts - timedelta(days=1))
 			tsNext = triggers[i+1].ts if i < len(triggers)-1 else (trig.ts + timedelta(days=1))
 			deltaFinish = min( (trig.ts-tsPrev).total_seconds(), (tsNext-trig.ts).total_seconds() )
-			row = self.triggerList.InsertItem( 999999, trig.ts.strftime('%H:%M:%S.%f')[:-3], getCloseFinishIndex(deltaFinish) )
+			#row = self.triggerList.InsertItem( 999999, trig.ts.strftime('%H:%M:%S.%f')[:-3], getCloseFinishIndex(deltaFinish) )  #this seems to cause incorrect item order under Windows - KW
+	￼			row = self.triggerList.InsertItem( self.triggerList.GetItemCount(), trig.ts.strftime('%H:%M:%S.%f')[:-3], getCloseFinishIndex(deltaFinish) )  #always appends to the bottom of the list
 			
 			self.updateTriggerRow( row, trig._asdict() )			
 			self.triggerList.SetItemData( row, trig.id )	# item data is the trigger id.


### PR DESCRIPTION
Fix for #112 

It appears that repeatedly inserting items in wx.ListCtrl at the same index gives an undefined order?  I'm seeing the list in descending order under Windows, but not Linux.

Style `wx.LC_SORT_ASCENDING` is set, but [it appears this has no effect unless a callback is set](https://docs.wxpython.org/wx.ListCtrl.html).

Using `GetItemCount()` for the append corrects this behaviour, as the triggers are always inserted at a different index.

