### PR TITLE
Crossmgrvideo improvements

### DIFF
--- a/CrossMgrVideo/ComputeSpeed.py
+++ b/CrossMgrVideo/ComputeSpeed.py
@@ -48,7 +48,7 @@ class WheelEdgesPage(adv.WizardPageSimple):
 		self.wheelSelector.SetSelection(WheelEdgesPage.defaultWheelSize)
 		self.wheelSelector.Bind( wx.EVT_COMBOBOX, self.onselectWheel )
 		self.wheelSelector.Bind( wx.EVT_TEXT_ENTER, self.onEnterWheel )
-		hbs.Add( wx.StaticText(self, label = _('Select wheel size or enter diamter (mm):')), flag=wx.TOP|wx.LEFT|wx.RIGHT, border = border )
+		hbs.Add( wx.StaticText(self, label = _('Select wheel size or enter diameter (mm):')), flag=wx.TOP|wx.LEFT|wx.RIGHT, border = border )
 		hbs.Add( self.wheelSelector, flag=wx.LEFT, border=2)
 		
 		vbsSettings.Add( hbs, flag=wx.LEFT, border=2)

--- a/CrossMgrVideo/MainWin.py
+++ b/CrossMgrVideo/MainWin.py
@@ -30,7 +30,6 @@ import sqlite3
 from time import sleep
 import numpy as np
 from queue import Queue, Empty
-import ast
 
 from datetime import datetime, date, timedelta, time
 
@@ -636,12 +635,11 @@ class MainWin( wx.Frame ):
 		images.extend( [self.sm_up, self.sm_dn] )
 		self.triggerList.SetSmallImages( images )
 		
-		self.fieldCol = {f:c for c, f in enumerate('ts bib name machine team wave race_name frames view kmh mph note'.split())}
-		self.fieldHeaders = ['Time', 'Bib', 'Name', 'Machine', 'Team', 'Wave', 'Race', 'Frames', 'View', 'km/h', 'mph', 'Note']
+		self.fieldCol = {f:c for c, f in enumerate('ts bib name team wave race_name frames view kmh mph note'.split())}
+		headers = ['Time', 'Bib', 'Name', 'Team', 'Wave', 'Race', 'Frames', 'View', 'km/h', 'mph', 'Note']
 		formatRightHeaders = {'Bib','Frames','km/h','mph'}
 		formatMiddleHeaders = {'View',}
-		self.hiddenTriggerCols = []
-		for i, h in enumerate(self.fieldHeaders):
+		for i, h in enumerate(headers):
 			if h in formatRightHeaders:
 				align = wx.LIST_FORMAT_RIGHT
 			elif h in formatMiddleHeaders:
@@ -656,7 +654,6 @@ class MainWin( wx.Frame ):
 		self.triggerList.Bind( wx.EVT_LIST_ITEM_RIGHT_CLICK, self.onTriggerRightClick )
 		self.triggerList.Bind( wx.EVT_LIST_KEY_DOWN, self.onTriggerKey )
 		#self.triggerList.Bind( wx.EVT_LIST_DELETE_ITEM, self.onTriggerDelete )
-		self.triggerList.Bind( wx.EVT_LIST_COL_RIGHT_CLICK, self.onTriggerColumnRightClick )
 		
 		vsTriggers = wx.BoxSizer( wx.VERTICAL )
 		vsTriggers.Add( hsDate )
@@ -700,7 +697,7 @@ class MainWin( wx.Frame ):
 		self.messageThread = threading.Thread( target=self.showMessages, daemon=True )
 		self.messageThread.start()
 		
-		wx.CallLater( 300, self.refreshTriggers, selectLatest=True )
+		wx.CallLater( 300, self.refreshTriggers )
 		
 		# Add event handlers to the app as this is the last window to process events.
 		'''
@@ -1051,7 +1048,7 @@ class MainWin( wx.Frame ):
 				tsBest, jpgBest = GlobalDatabase().getBestTriggerPhoto( info['id'] )
 				if jpgBest is None:
 					continue
-				args = {k:info[k] for k in ('ts', 'bib', 'first_name', 'last_name', 'machine', 'team', 'race_name', 'kmh')}
+				args = {k:info[k] for k in ('ts', 'bib', 'first_name', 'last_name', 'team', 'race_name', 'kmh')}
 				try:
 					args['raceSeconds'] = (info['ts'] - info['ts_start']).total_seconds()
 				except Exception:
@@ -1067,7 +1064,7 @@ class MainWin( wx.Frame ):
 						info['first_name'],
 					)
 				)
-				comment = json.dumps( {k:info[k] for k in ('bib', 'first_name', 'last_name', 'machine', 'team', 'race_name')} )
+				comment = json.dumps( {k:info[k] for k in ('bib', 'first_name', 'last_name', 'team', 'race_name')} )
 				try:
 					with open(os.path.join(dirname, fname), 'wb') as f:
 						f.write( AddExifToJpeg(jpg, info['ts'], comment) )
@@ -1140,7 +1137,7 @@ class MainWin( wx.Frame ):
 
 						if jpgBest is None:
 							continue
-						args = {k:info[k] for k in ('ts', 'bib', 'first_name', 'last_name', 'machine', 'team', 'race_name', 'kmh')}
+						args = {k:info[k] for k in ('ts', 'bib', 'first_name', 'last_name', 'team', 'race_name', 'kmh')}
 						try:
 							args['raceSeconds'] = (info['ts'] - info['ts_start']).total_seconds()
 						except Exception:
@@ -1148,7 +1145,7 @@ class MainWin( wx.Frame ):
 						if isinstance(args['kmh'], str):
 							args['kmh'] = float( '0' + re.sub( '[^0-9.]', '', args['kmh'] ) )
 
-						comment = json.dumps( {k:info[k] for k in ('bib', 'first_name', 'last_name', 'machine', 'team', 'race_name')} )
+						comment = json.dumps( {k:info[k] for k in ('bib', 'first_name', 'last_name', 'team', 'race_name')} )
 						jpg = CVUtil.bitmapToJPeg( AddPhotoHeader(CVUtil.jpegToBitmap(jpgBest), **args) )
 						jpg = AddExifToJpeg( jpg, info['ts'], comment )
 
@@ -1196,11 +1193,7 @@ class MainWin( wx.Frame ):
 
 	def updateTriggerColumnWidths( self ):
 		for c in range(self.triggerList.GetColumnCount()):
-			if not c in self.hiddenTriggerCols:
-				self.triggerList.SetColumnWidth(c, wx.LIST_AUTOSIZE_USEHEADER if c != self.iNoteCol else 100 )
-			else:
-				#if column is hidden, just set the width to zero
-				self.triggerList.SetColumnWidth( c, 0 )
+			self.triggerList.SetColumnWidth(c, wx.LIST_AUTOSIZE_USEHEADER if c != self.iNoteCol else 100 )
 				
 	def updateTriggerRow( self, row, fields ):
 		''' Update the row in the UI only. '''
@@ -1238,21 +1231,18 @@ class MainWin( wx.Frame ):
 	def getTriggerInfo( self, row ):
 		return self.computeTriggerFields( GlobalDatabase().getTriggerFields(self.triggerList.GetItemData(row)) )
 	
-	def refreshTriggers( self, replace=False, iTriggerRow=None, selectLatest=None):
+	def refreshTriggers( self, replace=False, iTriggerRow=None ):
 		'''
 			Refreshes the trigger list from the database.
 			If any rows have zero frames, it fixes the number of frames by reading the database.
 		'''
 		tNow = now()
-		
-		if selectLatest == None:
-			selectLatest = self.selectLatest.GetValue()
 
 		if replace:
 			tsLower = self.tsQueryLower
 			tsUpper = self.tsQueryUpper
 		elif self.tsQueryUpper < date(tNow.year, tNow.month, tNow.day): #if a historical date is selected
-			if selectLatest:
+			if self.selectLatest.GetValue():
 				#replace list with the current day's
 				replace = True
 				tsLower = (self.tsMax or datetime(tNow.year, tNow.month, tNow.day)) + timedelta(seconds=0.00001)
@@ -1267,7 +1257,7 @@ class MainWin( wx.Frame ):
 		else:
 			tsLower = (self.tsMax or datetime(tNow.year, tNow.month, tNow.day)) + timedelta(seconds=0.00001)
 			tsUpper = tsLower + timedelta(days=1)
-			
+
 		# Read the triggers from the database before we repaint the screen to avoid flashing.
 		counts = GlobalDatabase().updateTriggerPhotoCountInterval( tsLower, tsUpper )
 		triggers = GlobalDatabase().getTriggers( tsLower, tsUpper, self.bibQuery )		
@@ -1278,7 +1268,7 @@ class MainWin( wx.Frame ):
 		self.finishStrip.Set( None )
 		
 		if replace:
-			#self.tsMax = None  #this causes duplicate entries when not replacing
+			self.tsMax = None
 			self.iTriggerSelect = None
 			self.triggerInfo = {}
 			self.triggerList.DeleteAllItems()
@@ -1293,6 +1283,7 @@ class MainWin( wx.Frame ):
 			tsNext = triggers[i+1].ts if i < len(triggers)-1 else (trig.ts + timedelta(days=1))
 			deltaFinish = min( (trig.ts-tsPrev).total_seconds(), (tsNext-trig.ts).total_seconds() )
 			row = self.triggerList.InsertItem( self.triggerList.GetItemCount(), trig.ts.strftime('%H:%M:%S.%f')[:-3], getCloseFinishIndex(deltaFinish) )
+			
 			self.updateTriggerRow( row, trig._asdict() )			
 			self.triggerList.SetItemData( row, trig.id )	# item data is the trigger id.
 			tsPrev = trig.ts
@@ -1311,7 +1302,7 @@ class MainWin( wx.Frame ):
 			iTriggerRow = min( max(0, iTriggerRow), self.triggerList.GetItemCount()-1 )
 			
 		self.triggerList.EnsureVisible( iTriggerRow )
-		if selectLatest:
+		if self.selectLatest.GetValue():
 			self.triggerList.Select( iTriggerRow )
 			wx.CallAfter( self.onTriggerSelected, iTriggerSelect=iTriggerRow or 0 )
 
@@ -1339,7 +1330,6 @@ class MainWin( wx.Frame ):
 				'bib':				self.snapshotCount,
 				'first_name':		'',
 				'last_name':		'Snapshot',
-				'machine':			'',
 				'team':				'',
 				'wave':				'',
 				'race_name':		'',
@@ -1647,29 +1637,6 @@ class MainWin( wx.Frame ):
 		self.iTriggerSelect = event.Index
 		self.doTriggerEdit()
 		
-	def onTriggerColumnRightClick( self, event ):
-		# Create and display a popup menu of columns on right-click event
-		menu = wx.Menu()
-		menu.SetTitle( 'Show/Hide columns' )
-		for c in range(self.triggerList.GetColumnCount()):
-			menuItem = menu.AppendCheckItem( wx.ID_ANY, self.fieldHeaders[c] )
-			self.Bind(wx.EVT_MENU, self.onToggleTriggerColumn)
-			if not c in self.hiddenTriggerCols:
-				menu.Check( menuItem.GetId(), True )
-		self.PopupMenu(menu)
-		menu.Destroy()
-		
-	def onToggleTriggerColumn( self, event ):
-		#find the column number
-		label = event.GetEventObject().FindItemById(event.GetId()).GetItemLabel()
-		c = self.fieldHeaders.index(label)
-		#add or remove from hidden columns and update width
-		if c in self.hiddenTriggerCols:
-			self.hiddenTriggerCols.remove( c )
-		else:
-			self.hiddenTriggerCols.append( c )
-		self.updateTriggerColumnWidths()
-		
 	def showMessages( self ):
 		while True:
 			message = self.messageQ.get()
@@ -1818,7 +1785,6 @@ class MainWin( wx.Frame ):
 						'bib':				msg.get('bib', 99999),
 						'first_name':		msg.get('first_name','') or msg.get('firstName',''),
 						'last_name':		msg.get('last_name','') or msg.get('lastName',''),
-						'machine':			msg.get('machine',''),
 						'team':				msg.get('team',''),
 						'wave':				msg.get('wave',''),
 						'race_name':		msg.get('race_name','') or msg.get('raceName',''),
@@ -1949,7 +1915,6 @@ class MainWin( wx.Frame ):
 		self.config.Write( 'SecondsBefore', '{:.3f}'.format(self.tdCaptureBefore.total_seconds()) )
 		self.config.Write( 'SecondsAfter', '{:.3f}'.format(self.tdCaptureAfter.total_seconds()) )
 		self.config.WriteFloat( 'ZoomMagnification', self.finishStrip.GetZoomMagnification() )
-		self.config.Write( 'HiddenTriggerCols', repr(self.hiddenTriggerCols) )
 		self.config.WriteInt( 'ClosestFrames', self.autoCaptureClosestFrames )
 		self.config.WriteBool ('SelectLatest', self.selectLatest.GetValue() )
 		self.config.Flush()
@@ -1971,7 +1936,6 @@ class MainWin( wx.Frame ):
 		except Exception:
 			pass
 		self.finishStrip.SetZoomMagnification( self.config.ReadFloat('ZoomMagnification', 0.5) )
-		self.hiddenTriggerCols = ast.literal_eval( self.config.Read( 'HiddenTriggerCols', '[]' ) )
 		self.autoCaptureClosestFrames = self.config.ReadInt( 'ClosestFrames', 0 )
 		self.selectLatest.SetValue( self.config.ReadBool( 'SelectLatest', True ) )
 		

--- a/CrossMgrVideo/MainWin.py
+++ b/CrossMgrVideo/MainWin.py
@@ -386,6 +386,7 @@ class MainWin( wx.Frame ):
 		self.frameCount = 0
 		self.fpt = timedelta(seconds=0)
 		self.iTriggerSelect = None
+		self.iTriggerAdded = None
 		self.triggerInfo = None
 		self.tsMax = None
 		self.inCapture = 0	# Use an integer so we can support reentrant captures.
@@ -618,9 +619,9 @@ class MainWin( wx.Frame ):
 		self.publishWebPage.Bind( wx.EVT_BUTTON, self.onPublishWebPage )
 		hsDate.Add( self.publishWebPage, flag=wx.ALIGN_CENTER_VERTICAL|wx.LEFT, border=32 )
 		
-		self.selectLatest = wx.CheckBox( self, label="Select latest" )
-		self.selectLatest.Bind (wx.EVT_CHECKBOX, self.onToggleSelectLatest )
-		hsDate.Add( self.selectLatest, flag=wx.ALIGN_CENTER_VERTICAL|wx.LEFT, border=32 )
+		self.autoSelect = wx.Choice( self, choices=['Autoselect latest', 'Fast preview', 'Autoselect off'] )
+		self.autoSelect.Bind (wx.EVT_CHOICE, self.onAutoSelect )
+		hsDate.Add( self.autoSelect, flag=wx.ALIGN_CENTER_VERTICAL|wx.LEFT, border=32 )
 		
 		self.tsQueryLower = date(tQuery.year, tQuery.month, tQuery.day)
 		self.tsQueryUpper = self.tsQueryLower + timedelta(days=1)
@@ -1020,6 +1021,8 @@ class MainWin( wx.Frame ):
 		wx.CallAfter( self.photoPanel.doRestoreView, self.triggerInfo )
 		
 	def onNotebook( self, event ):
+		self.iTriggerAdded = None
+		self.onTriggerSelected()
 		self.refreshPhotoPanel()
 		
 	def onPublishPhotos( self, event ):
@@ -1175,8 +1178,14 @@ class MainWin( wx.Frame ):
 		threading.Thread( target=publish_web_photos, args=args, name='publish_web', daemon=True ).start()
 		# write_photos( *args )
 		
-	def onToggleSelectLatest(self, event):
-		self.refreshTriggers()
+	def onAutoSelect(self, event):
+		if self.autoSelect.GetCurrentSelection() == 0:
+			tNow = now()
+			self.tsQueryLower = date(tNow.year, tNow.month, tNow.day)
+			self.tsQueryUpper = self.tsQueryLower + timedelta( days=1 )
+			wx.CallAfter( self.date.SetValue, wx.DateTime(tNow.day, tNow.month-1, tNow.year) )
+			self.iTriggerAdded = None
+			self.refreshTriggers(replace=True)
 		self.writeOptions()
 	
 	def GetListCtrl( self ):
@@ -1238,8 +1247,8 @@ class MainWin( wx.Frame ):
 		'''
 		tNow = now()
 
-		if selectLatest == None:
-			selectLatest = self.selectLatest.GetValue()
+		if selectLatest == None and self.autoSelect.GetSelection() < 2:
+			selectLatest = True
 
 		if replace:
 			tsLower = self.tsQueryLower
@@ -1306,8 +1315,10 @@ class MainWin( wx.Frame ):
 			
 		self.triggerList.EnsureVisible( iTriggerRow )
 		if selectLatest:
+			if not replace:
+				self.iTriggerAdded = iTriggerRow
 			self.triggerList.Select( iTriggerRow )
-			wx.CallAfter( self.onTriggerSelected, iTriggerSelect=iTriggerRow or 0 )
+			#wx.CallAfter( self.onTriggerSelected, iTriggerSelect=iTriggerRow or 0 )  # this appears to be unecessary as the Select() generates an event
 
 	def dbInactivityUpdate( self ):
 		# Do actions when the database goes inactive.
@@ -1534,8 +1545,7 @@ class MainWin( wx.Frame ):
 		self.camInQ.put( {'cmd':'send_update', 'name':'focus', 'freq':1} )
 		self.focusDialog.Show()
 	
-	def onTriggerSelected( self, event=None, iTriggerSelect=None ):
-		
+	def onTriggerSelected( self, event=None, iTriggerSelect=None, fastPreview=False):
 		# Determine which trigger we are updating (either specified or from the event).
 		if iTriggerSelect is None:
 			if event is not None:
@@ -1555,7 +1565,13 @@ class MainWin( wx.Frame ):
 				return
 			else:
 				self.iTriggerSelect = self.triggerList.GetItemCount() - 1
-				
+		
+		# If this is a newly added trigger, should we do a fast preview?
+		if self.iTriggerSelect == self.iTriggerAdded:
+			fastPreview = self.autoSelect.GetSelection() == 1
+		else:
+			self.iTriggerAdded = None
+			
 		# Update the screen based on the new trigger.
 		with wx.BusyCursor():
 			self.finishStrip.Set( None )	# Clear the current finish strip so nothing gets updated.
@@ -1572,18 +1588,31 @@ class MainWin( wx.Frame ):
 			self.ts = triggerInfo['ts']
 			if triggerInfo['closest_frames']:
 				self.tsJpg = GlobalDatabase().getPhotosClosest( self.ts, triggerInfo['closest_frames'] )
+			elif fastPreview:
+				# Only fetch a single frame; this is considerably faster
+				self.tsJpg = GlobalDatabase().getPhotosClosest( self.ts, 1 )
 			else:
 				self.tsJpg = GlobalDatabase().getPhotos( self.ts - timedelta(seconds=s_before), self.ts + timedelta(seconds=s_after) )
 			
 			# Update the frame information.
-			if triggerInfo['frames'] != len(self.tsJpg):
+			if not fastPreview and triggerInfo['frames'] != len(self.tsJpg):
 				triggerInfo['frames'] = len(self.tsJpg)
 				self.dbWriterQ.put( ('photoCount', self.triggerInfo['id'], len(self.tsJpg)) )
 				self.updateTriggerRow( self.iTriggerSelect, {'frames':len(self.tsJpg)} )
 			
 			# Update the main UI.
-			self.finishStrip.Set( self.tsJpg, leftToRight=[None, True, False][triggerInfo.get('finish_direction', 0)], triggerTS=triggerInfo['ts'] )
-			self.refreshPhotoPanel()
+			if fastPreview:
+				# Switch to Images tab
+				if self.notebook.GetSelection() != 0:
+					self.notebook.ChangeSelection(0)  # This does not generate a page change event
+				# Directly draw the frame on the photoPanel without populating the finishStrip
+				self.photoPanel.set(1, None, self.tsJpg, self.fps, editCB=None, updateCB=None )
+				# De-select the trigger and clear self.iTriggerAdded so re-selecting the trigger causes a full fetch
+				self.triggerList.Select( -1, on=False )
+				self.iTriggerAdded = None
+			else:
+				self.finishStrip.Set( self.tsJpg, leftToRight=[None, True, False][triggerInfo.get('finish_direction', 0)], triggerTS=triggerInfo['ts'] )
+				self.refreshPhotoPanel()
 	
 	def onTriggerRightClick( self, event ):
 		self.iTriggerSelect = event.Index
@@ -1919,7 +1948,7 @@ class MainWin( wx.Frame ):
 		self.config.Write( 'SecondsAfter', '{:.3f}'.format(self.tdCaptureAfter.total_seconds()) )
 		self.config.WriteFloat( 'ZoomMagnification', self.finishStrip.GetZoomMagnification() )
 		self.config.WriteInt( 'ClosestFrames', self.autoCaptureClosestFrames )
-		self.config.WriteBool ('SelectLatest', self.selectLatest.GetValue() )
+		self.config.WriteInt ('AutoSelect', self.autoSelect.GetSelection() )
 		self.config.Flush()
 	
 	def readOptions( self ):
@@ -1940,7 +1969,7 @@ class MainWin( wx.Frame ):
 			pass
 		self.finishStrip.SetZoomMagnification( self.config.ReadFloat('ZoomMagnification', 0.5) )
 		self.autoCaptureClosestFrames = self.config.ReadInt( 'ClosestFrames', 0 )
-		self.selectLatest.SetValue( self.config.ReadBool( 'SelectLatest', True ) )
+		self.autoSelect.SetSelection( self.config.ReadInt( 'AutoSelect', 0 ) )
 		
 	def getCameraInfo( self ):
 		width, height = self.getCameraResolution()

--- a/CrossMgrVideo/MainWin.py
+++ b/CrossMgrVideo/MainWin.py
@@ -697,7 +697,7 @@ class MainWin( wx.Frame ):
 		self.messageThread = threading.Thread( target=self.showMessages, daemon=True )
 		self.messageThread.start()
 		
-		wx.CallLater( 300, self.refreshTriggers )
+		wx.CallLater( 300, self.refreshTriggers, selectLatest=True )
 		
 		# Add event handlers to the app as this is the last window to process events.
 		'''
@@ -1231,18 +1231,21 @@ class MainWin( wx.Frame ):
 	def getTriggerInfo( self, row ):
 		return self.computeTriggerFields( GlobalDatabase().getTriggerFields(self.triggerList.GetItemData(row)) )
 	
-	def refreshTriggers( self, replace=False, iTriggerRow=None ):
+	def refreshTriggers( self, replace=False, iTriggerRow=None, selectLatest=None):
 		'''
 			Refreshes the trigger list from the database.
 			If any rows have zero frames, it fixes the number of frames by reading the database.
 		'''
 		tNow = now()
 
+		if selectLatest == None:
+			selectLatest = self.selectLatest.GetValue()
+
 		if replace:
 			tsLower = self.tsQueryLower
 			tsUpper = self.tsQueryUpper
 		elif self.tsQueryUpper < date(tNow.year, tNow.month, tNow.day): #if a historical date is selected
-			if self.selectLatest.GetValue():
+			if selectLatest:
 				#replace list with the current day's
 				replace = True
 				tsLower = (self.tsMax or datetime(tNow.year, tNow.month, tNow.day)) + timedelta(seconds=0.00001)
@@ -1302,7 +1305,7 @@ class MainWin( wx.Frame ):
 			iTriggerRow = min( max(0, iTriggerRow), self.triggerList.GetItemCount()-1 )
 			
 		self.triggerList.EnsureVisible( iTriggerRow )
-		if self.selectLatest.GetValue():
+		if selectLatest:
 			self.triggerList.Select( iTriggerRow )
 			wx.CallAfter( self.onTriggerSelected, iTriggerSelect=iTriggerRow or 0 )
 

--- a/CrossMgrVideo/helptxt/QuickStart.md
+++ b/CrossMgrVideo/helptxt/QuickStart.md
@@ -126,11 +126,15 @@ __CrossMgrVideo__ can capture video up to 10 seconds "in the past" because it ke
 
 Takes a single snapshot and saves it to the database.
 
+__Snapshot__ can be triggered by a joystick.  Snapshot is triggered when the third joystick button is pressed.
+
 #### Auto Capture
 
 Captures frames as specified by the __Auto Capture__ dialog described above.
 
 __Auto Capture__ can be triggered by pressing the 'A' key or the Space Bar.
+
+__Auto Capture__ can be triggered by a joystick.  Auto Capture starts when the second joystick button is pressed.
 
 #### Capture
 
@@ -222,6 +226,10 @@ Publishes the photo closest to each Trigger time to a chosen folder.
 __Photo Web Page__
 
 Publishes the photo closest to each Trigger time to a chosen folder, but also creates an html page that can select each photo.  Once the photo is selected, it supports the same drag-and-drop Zoom capability of CrossMgrVideo.  Photos can be saved locally from the web page.
+
+__Select latest__
+
+If ticked, automatically selects the latest Trigger after it arrives.  If unticked the trigger list will update to show new triggers, but the currently selected trigger remains selected.
 
 ## Web Interface
 

--- a/CrossMgrVideo/helptxt/QuickStart.md
+++ b/CrossMgrVideo/helptxt/QuickStart.md
@@ -227,9 +227,13 @@ __Photo Web Page__
 
 Publishes the photo closest to each Trigger time to a chosen folder, but also creates an html page that can select each photo.  Once the photo is selected, it supports the same drag-and-drop Zoom capability of CrossMgrVideo.  Photos can be saved locally from the web page.
 
-__Select latest__
+__Autoselect__
 
-If ticked, automatically selects the latest Trigger after it arrives.  If unticked the trigger list will update to show new triggers, but the currently selected trigger remains selected.
+Determines the behaviour when a new trigger is captured:
+
+* Autoselect latest: Selects the new trigger for analysis after it arrives.
+* Fast preview: Displays a single frame from the trigger as quickly as possible, for monitoring captures during a race.  (This is considerably faster than loading all the frames.)
+* Autoselect off: New triggers will be added to the list, but the current selection is unaffected.  Useful for examining existing triggers while a race is in progress.
 
 ## Web Interface
 


### PR DESCRIPTION
Several related improvements to CrossMgrVideo that are probably worth including in the official version:

Firstly, a widget that selects how the Triggerlist behaves when a new capture is made.  Options are:
'Auto select' - the normal behaviour, where the latest trigger is selected automatically.
'Fast preview' - retrieves a single frame for the trigger from the database and draws it directly on the PhotoPanel, which is considerably faster (I'm seeing ~10ms vs up to a couple of seconds for ~400 frame triggers).  The trigger is left un-selected in the list, so the user can click on it to load all the frames (switching to the Finish Strip view will also cause it to be loaded).
'Autoselect off' - the trigger is added to the list, but the current selection is unaffected.  Useful if you want to review a trigger while captures may occur.

As part of implementing this, I've fixed the self.tsMax-related date issues described in #112 - the selected date is now reset properly to the current day when jumping to a new capture.

I've removed a call to `wx.CallAfter( self.onTriggerSelected )` when selecting a new trigger at the end of `refreshTriggers()`, because `self.triggerList.Select()` fires an event to do this already.  This means `onTriggerSelected()` no longer runs twice after a refresh, which presumably improves performance.

Added support for single frame capture via joystick button 3 for completeness, and indicate in the name field when captures are triggered by the joystick (this was useful to me when testing a beam-break trigger device).

Also fixed a bug in the Compute Speed wizard where the image was rendered over the top of the wizard navigation controls on the second page.  Added a combo-box selection of some standard wheel sizes (which I'd imagine the juniors and MTBers would also appreciate), and allow free-form entry of a wheel diameter in millimetres.

