### PR TITLE
Add wx import to WebServer.py

### DIFF
--- a/WebServer.py
+++ b/WebServer.py
@@ -1,6 +1,7 @@
 import os
 import io
 import re
+import wx
 import sys
 import gzip
 import glob


### PR DESCRIPTION
/rfid.js & /bib.js handlers both reference wx but import is missing, built and tested at an event with this extra import, works as expected