### PR TITLE
Remove and roll-back ResultNote changes.

### DIFF
--- a/MainWin.py
+++ b/MainWin.py
@@ -56,7 +56,6 @@ from GapChart			import GapChart
 from LapCounter			import LapCounter
 from Announcer			import Announcer
 from Primes				import Primes, GetGrid
-from ResultNote			import ResultNote
 from Prizes				import Prizes
 from HistogramPanel		import HistogramPanel
 from UnmatchedTagsGantt	import UnmatchedTagsGantt
@@ -690,7 +689,6 @@ class MainWin( wx.Frame ):
 			[ 'categories', 	Categories,			_('Categories') ],
 			[ 'properties',		Properties,			_('Properties') ],
 			[ 'primes',			Primes,				_('Primes') ],
-			[ 'resultNote',		ResultNote,			_('Result Notes') ],
 			[ 'prizes',			Prizes,				_('Prizes') ],
 			[ 'raceAnimation',	RaceAnimation,		_('Animation') ],
 			#[ 'situation',		Situation,			_('Situation') ],


### PR DESCRIPTION
ResultNote has been imported in the latest release, however I can find no other references in development branches as to where this file might have been - I've not been able to find a commit of the actual file.

I would consider this an urgent fix to get `master` to actually run - however it does compile and build installers, which is concerning.

See https://github.com/esitarski/CrossMgr/issues/158