### PR TITLE
Change existing log functions to use new logger

### DIFF
--- a/Log.py
+++ b/Log.py
@@ -1,0 +1,79 @@
+import inspect
+import logging
+import sys
+import threading
+from typing import Any
+
+lock = threading.Lock()
+
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+traceFormatter = logging.Formatter('%(asctime)s - %(name)s@%(filename)s:%(lineno)d:%(funcName)s - %(levelname)s - %(message)s')
+# Create a handler that writes log messages to stdout
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+
+errHandler = logging.StreamHandler(sys.stderr)
+errHandler.setLevel(logging.ERROR)
+
+# Create a formatter and set it for the handler
+handler.setFormatter(formatter)
+errHandler.setFormatter(formatter)
+
+class Log:
+	TRACE = 6
+	ENTER = 4
+	EXIT = 2
+	RETURN = 3
+	APPLICATION_END = 5
+
+class CrossMgrLogger(logging.Logger):
+	def __init__(self, name: str, level: int | str = 0) -> None:
+		super().__init__(name, level)
+		super().addHandler(handler)
+		super().addHandler(errHandler)
+
+	def log(self, level: int, msg: object, *args: object, **kwargs: Any) -> None:
+		if level == Log.ENTER < logging.DEBUG:
+			filename, lineNumber, functionName, stack = self.findCaller()
+			caller = '{}:{}#{}'.format(filename, lineNumber, functionName)
+			updatedMsg = '{}: {}'.format(caller, msg)
+			return super().log(level, updatedMsg, *args, **kwargs)
+
+		return super().log(level, msg, args, kwargs)
+
+	def entering(self, msg: object, *args: object, **kwargs: Any) -> None:
+		return self.log(Log.ENTER, msg, *args, **kwargs)
+
+	def exiting(self, msg: object, *args: object, **kwargs: Any) -> None:
+		return self.log(Log.EXIT, msg, *args, **kwargs)
+
+	def trace(self, msg: object, *args: object, **kwargs: Any) -> None:
+		return self.log(Log.TRACE, msg, *args, **kwargs)
+
+	def returning(self, msg: object, *args: object, **kwargs: Any) -> None:
+		return self.log(Log.RETURN, msg, *args, **kwargs)
+
+	def exitApp(self, msg: object = 'Application exiting', *args: object, **kwargs: Any) -> None:
+		return self.log(Log.APPLICATION_END, msg, *args, **kwargs)
+
+def getLogger(name: str = None, level: int = logging.INFO) -> CrossMgrLogger:
+	if name is None:
+		frame = inspect.stack()[1]
+		module = inspect.getmodule(frame[0])
+		logger_name = module.__name__ if module else '__main__'
+	else:
+		logger_name = name
+
+	with lock:
+		lastLogger = logging.getLoggerClass()
+		logging.setLoggerClass(CrossMgrLogger)
+
+		log = logging.getLogger(logger_name)
+		assert isinstance(log, CrossMgrLogger)
+		if lastLogger != CrossMgrLogger:
+			logging.setLoggerClass(lastLogger)
+
+		log.setLevel(level)
+
+	return log
+

--- a/Utils.py
+++ b/Utils.py
@@ -8,6 +8,7 @@ isWindows = sys.platform.startswith('win')
 #
 import wx
 import os
+from Log import getLogger
 
 import wx.lib.agw.genericmessagedialog
 
@@ -592,20 +593,8 @@ def approximateMatch( s1, s2 ):
 PlatformName = platform.system()
 AppVer = 'v' + AppVerName.split(' ')[1]
 def writeLog( message ):
-	try:
-		dt = datetime.datetime.now()
-		dt = dt.replace( microsecond = 0 )
-		msg = '{} ({} {}) {}{}'.format(
-			dt.isoformat(),
-			AppVer,
-			PlatformName,
-			message,
-			'\n' if not message or message[-1] != '\n' else '',
-		)
-		sys.stdout.write( removeDiacritic(msg) )
-		sys.stdout.flush()
-	except IOError:
-		pass
+	log = getLogger()
+	log.info( message )
 
 def disable_stdout_buffering():
 	# No longer necessary as if output goes to the terminal it will be flushed if it ends in newline.
@@ -621,14 +610,9 @@ def logCall( f ):
 		return f( *args, **kwargs)
 	return new_f
 	
-def logException( e, exc_info ):
-	eType, eValue, eTraceback = exc_info
-	ex = traceback.format_exception( eType, eValue, eTraceback )
-	writeLog( '**** Begin Exception ****' )
-	for d in ex:
-		for line in d.split( '\n' ):
-			writeLog( line )
-	writeLog( '**** End Exception ****' )
+def logException( e: Exception, exc_info ) -> None:
+	log = getLogger()
+	log.exception( e )
 
 #------------------------------------------------------------------------
 mainWin = None


### PR DESCRIPTION
This is the second of two initial log-related PRs which moves existing log functions and annotation/decorator log events for function calls to call the new Log util class, allowing a customer handler and levels to be defined for different calls.

This one is more optional, but it makes much more sense if a proper logging framework is in place to not have some code write straight to stdout/stderr.

It's currently based on the previous PR, but can be rebased on to `master` once https://github.com/esitarski/CrossMgr/pull/162 is merged.