### PR TITLE
Fix missing startlist on TT countdown and startlist pages

### DIFF
--- a/MainWin.py
+++ b/MainWin.py
@@ -2325,12 +2325,12 @@ class MainWin( wx.Frame ):
 						return c
 			return category
 		
-		Finisher = Model.Rider.Finisher
+		NP = Model.Rider.NP
 		startList = []
 		nationCodes = set()
 		category = None
 		for bib, rider in race.riders.items():
-			if rider.status == Finisher:
+			if rider.status == NP:
 				try:
 					firstTime = int(rider.firstTime + 0.1)
 				except Exception:


### PR DESCRIPTION
Had an issue with the TT countdown and startlists not containing any riders when it was published via FTP on event start. 

Found that the initial status of all riders was `NP` rather than `FINISHER` as expected in the original code. I don't know if you know the source of the initial rider status changes to consider any other potential issues in the code? I know our CX start lists worked on the same code version. 

